### PR TITLE
fix: 🐛 update outDir in tsconfig to fix render deploy path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,7 +59,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "dist",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
The deployment failed on Render due to missing compiled `dist/app.js`.

BREAKING CHANGE: 🧨 Adjusted `"outDir"` in `tsconfig.json` to ensure TypeScript compiles to the correct path.